### PR TITLE
Добавлен новый параметр конфигурации ThrowPendingUpdates | Added new configuration option

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -3,6 +3,7 @@
         "Telegram": {
             "Token": "",
             "ChatIdLog": "",
+            "ThrowPendingUpdates": false,
             "DelaySendingMediaGroupMilliseconds": 30000,
             "MaxSizeMbPhoto": 5,
             "MaxSizeMbVideo": 20,

--- a/src/Bot.GetByLink.Client.Telegram.Common/Abstractions/TelegramClient.cs
+++ b/src/Bot.GetByLink.Client.Telegram.Common/Abstractions/TelegramClient.cs
@@ -47,7 +47,11 @@ public abstract class TelegramClient : GetByLink.Common.Abstractions.Client, IDi
 
         RegexWrappers = regexWrappers;
 
-        ReceiverOptions = new ReceiverOptions { AllowedUpdates = new[] { UpdateType.Message } };
+        ReceiverOptions = new ReceiverOptions
+        {
+            AllowedUpdates = new[] { UpdateType.Message },
+            ThrowPendingUpdates = config.Clients.Telegram.ThrowPendingUpdates
+        };
     }
 
     /// <summary>

--- a/src/Bot.GetByLink.Client.Telegram.Common/Model/Logging/TelegramLogger.cs
+++ b/src/Bot.GetByLink.Client.Telegram.Common/Model/Logging/TelegramLogger.cs
@@ -61,7 +61,7 @@ internal sealed class TelegramLogger : ILogger
         Func<TState, Exception?, string> formatter)
     {
         if (formatter is null || sendMessage is null || logChatId is null) return;
-        var message = new Message(logChatId, new List<string> { exception?.ToString() ?? formatter(state, exception) });
+        var message = new Message(logChatId, new List<string> { $"{formatter(state, exception)}\n{exception?.ToString()}" });
         sendMessage?.Invoke(message);
     }
 }

--- a/src/Bot.GetByLink.Client.Telegram.Common/Model/Logging/TelegramLogger.cs
+++ b/src/Bot.GetByLink.Client.Telegram.Common/Model/Logging/TelegramLogger.cs
@@ -61,7 +61,7 @@ internal sealed class TelegramLogger : ILogger
         Func<TState, Exception?, string> formatter)
     {
         if (formatter is null || sendMessage is null || logChatId is null) return;
-        var message = new Message(logChatId, new List<string> { $"{formatter(state, exception)}\n{exception?.ToString()}" });
+        var message = new Message(logChatId, new List<string> { $"{formatter(state, exception)}\n{exception}" });
         sendMessage?.Invoke(message);
     }
 }

--- a/src/Bot.GetByLink.Common.Infrastructure/Configuration/Clients/TelegramConfiguration.cs
+++ b/src/Bot.GetByLink.Common.Infrastructure/Configuration/Clients/TelegramConfiguration.cs
@@ -21,6 +21,12 @@ public sealed class TelegramConfiguration : ITelegramConfiguration
     public string ChatIdLog { get; init; } = string.Empty;
 
     /// <summary>
+    ///     Gets a value indicating whether specifies whether to discard all pending updates before polling starts.
+    /// </summary>
+    [JsonPropertyName("ThrowPendingUpdates")]
+    public bool ThrowPendingUpdates { get; init; } = false;
+
+    /// <summary>
     ///     Gets mediaGroup send delay in milliseconds.
     /// </summary>
     [JsonPropertyName("DelaySendingMediaGroupMilliseconds")]

--- a/src/Bot.GetByLink.Common.Interfaces/Configuration/Clients/ITelegramConfiguration.cs
+++ b/src/Bot.GetByLink.Common.Interfaces/Configuration/Clients/ITelegramConfiguration.cs
@@ -16,6 +16,11 @@ public interface ITelegramConfiguration
     public string ChatIdLog { get; init; }
 
     /// <summary>
+    ///     Gets a value indicating whether specifies whether to discard all pending updates before polling starts.
+    /// </summary>
+    public bool ThrowPendingUpdates { get; init; }
+
+    /// <summary>
     ///     Gets mediaGroup send delay in milliseconds.
     /// </summary>
     public int DelaySendingMediaGroupMilliseconds { get; init; }


### PR DESCRIPTION
### Проверить / Checks:

- [x] комментарии для документации с большой буквы | capitalized documentation comments;
- [x] `private set` / отсутcтвие `set` по возможности заменить на `init` | `privat set` / absence of `set`, if possible, replace with `init`;
- [x] добавить модификатор `sealed` к классам без наследников | add the `sealed` modifier to classes without descendants;
- [x] убрать кавычки `{}` с `namespace` | remove quotes `{}` from `namespace`;
- [x] все регулярные выражения обернуть в `IRegexWrapper` | wrap all regular expressions in `IRegexWrapper`;
- [x] добавить ссылки на [issues](https://github.com/AnatoliyCh/bot-get-by-link/issues) | add links to [issues](https://github.com/AnatoliyCh/bot-get-by-link/issues);
- [x] убрать лейбл **in progress** с закрепленных [issue](https://github.com/AnatoliyCh/bot-get-by-link/issues?q=is%3Aissue+is%3Aopen+label%3A%22in+progress%22) | remove **in progress** label from pinned [issue](https://github.com/AnatoliyCh/bot-get-by-link/issues?q=is%3Aissue+is%3Aopen+label%3A%22in+progress%22);
- [x] выполнить команду `dotnet jb cleanupcode Bot.GetByLink.sln` | run command `dotnet jb cleanupcode Bot.GetByLink.sln`;
- [x] соединить коммиты (squash) и дать адекватные названия | squash commits and give adequate names.
