### PR TITLE
Игнорирование регистра для команд и команда /start | Case-ignoring commands and the /start command

### DIFF
--- a/src/Bot.GetByLink.Client.Telegram.Common/Abstractions/TelegramClient.cs
+++ b/src/Bot.GetByLink.Client.Telegram.Common/Abstractions/TelegramClient.cs
@@ -157,8 +157,8 @@ public abstract class TelegramClient : GetByLink.Common.Abstractions.Client, IDi
                     if (!commandRegex.IsMatch(input)) return null;
                     var commandNameText = Regex.Replace(input, "/", string.Empty);
                     commandNameText = string.Concat(commandNameText[0].ToString().ToUpper(), commandNameText.AsSpan(1));
-                    if (!Enum.IsDefined(typeof(CommandName), commandNameText)) return null;
-                    return Enum.Parse<CommandName>(commandNameText, true);
+                    Enum.TryParse(typeof(CommandName), commandNameText, true, out var result);
+                    return (CommandName?)result;
             }
 
         return null;

--- a/src/Bot.GetByLink.Client.Telegram.Common/Enums/CommandName.cs
+++ b/src/Bot.GetByLink.Client.Telegram.Common/Enums/CommandName.cs
@@ -6,6 +6,11 @@
 public enum CommandName
 {
     /// <summary>
+    ///     Starting a dialogue with the bot.
+    /// </summary>
+    Start,
+
+    /// <summary>
     ///     Help info the current chat.
     /// </summary>
     Help,

--- a/src/Bot.GetByLink.Client.Telegram.Common/Model/Commands/CommandInvoker.cs
+++ b/src/Bot.GetByLink.Client.Telegram.Common/Model/Commands/CommandInvoker.cs
@@ -55,6 +55,9 @@ public sealed class CommandInvoker : ICommandInvoker<CommandName>
             .Concat(new List<ICommand<CommandName>> { helpCommand, chatInfoCommand, sendContentFromUrl })
             .DistinctBy(command => command.Name)
             .ToDictionary(command => command.Name, command => command);
+
+        // start command == help command
+        commands.Add(CommandName.Start, helpCommand);
     }
 
     /// <summary>


### PR DESCRIPTION
### Проверить / Checks:

- [x] комментарии для документации с большой буквы | capitalized documentation comments;
- [x] `private set` / отсутcтвие `set` по возможности заменить на `init` | `privat set` / absence of `set`, if possible, replace with `init`;
- [x] добавить модификатор `sealed` к классам без наследников | add the `sealed` modifier to classes without descendants;
- [x] убрать кавычки `{}` с `namespace` | remove quotes `{}` from `namespace`;
- [x] все регулярные выражения обернуть в `IRegexWrapper` | wrap all regular expressions in `IRegexWrapper`;
- [x] добавить ссылки на [issues](https://github.com/AnatoliyCh/bot-get-by-link/issues) | add links to [issues](https://github.com/AnatoliyCh/bot-get-by-link/issues);
- [x] убрать лейбл **in progress** с закрепленных [issue](https://github.com/AnatoliyCh/bot-get-by-link/issues?q=is%3Aissue+is%3Aopen+label%3A%22in+progress%22) | remove **in progress** label from pinned [issue](https://github.com/AnatoliyCh/bot-get-by-link/issues?q=is%3Aissue+is%3Aopen+label%3A%22in+progress%22);
- [x] выполнить команду `dotnet jb cleanupcode Bot.GetByLink.sln` | run command `dotnet jb cleanupcode Bot.GetByLink.sln`;
- [x] соединить коммиты (squash) и дать адекватные названия | squash commits and give adequate names.
